### PR TITLE
Improve feedback if branch not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.5",
+  "version": "2.0.6",
   "license": "MIT",
   "name": "@mollie/crowdin-cli",
   "author": {

--- a/src/download.ts
+++ b/src/download.ts
@@ -29,7 +29,7 @@ export default async (isTS = false) => {
   if (isCommonErrorResponse(updateResponse)) {
     log.error(
       updateResponse.error.message ||
-        `Something went wrong while uploading the source file`
+        "Something went wrong while uploading the source file"
     );
     process.exit(1);
   }

--- a/src/download.ts
+++ b/src/download.ts
@@ -7,6 +7,7 @@ import {
   updateOrRestoreFile,
   exportFile,
   isCommonErrorResponse,
+  unwrapValidationErrorResponse,
 } from "./lib/crowdin";
 import log from "./utils/logging";
 import convertToKeyValue from "./utils/convert-to-key-value";
@@ -43,7 +44,17 @@ export default async (isTS = false) => {
   ).catch(data => {
     // A common error here is language codes defined in
     // `CROWDIN_LANGUAGES` that weren’t found in Crowdin.
-    log.error(data.error.message);
+
+    if (isCommonErrorResponse(data)) {
+      log.error(data.error.message);
+    }
+
+    if (unwrapValidationErrorResponse(data)?.code === "notInArray") {
+      log.error(
+        "Target language not found. Make sure `CROWDIN_LANGUAGES` is correct."
+      );
+    }
+
     process.exit(1);
   });
 

--- a/src/lib/crowdin.ts
+++ b/src/lib/crowdin.ts
@@ -9,6 +9,7 @@ import CrowdinApiClient, {
   ValidationErrorResponse,
   Error,
 } from "@crowdin/crowdin-api-client";
+import chalk from "chalk";
 import fs from "fs";
 import config from "../config";
 import { CrowdinResponse, ExportFileResponse } from "../types";
@@ -88,10 +89,22 @@ export const createFile = async (
 export const updateOrRestoreFile = async (
   branchName: string,
   file: fs.ReadStream
-): Promise<ResponseObject<SourceFilesModel.File>> => {
+): Promise<ResponseObject<SourceFilesModel.File> | CommonErrorResponse> => {
   const storage = await addStorage(file);
   const branches = await listBranches(branchName);
-  const branchId = branches.data[0].data.id;
+  const branchId = branches?.data[0]?.data?.id;
+
+  if (!branchId) {
+    return {
+      error: {
+        code: "branchNotFound",
+        message: `Couldn’t find a branch with the name ${chalk.bold(
+          branchName
+        )}`,
+      },
+    };
+  }
+
   const files = await listFiles(branchId);
   const fileId = files.data[0].data.id;
 

--- a/src/lib/crowdin.ts
+++ b/src/lib/crowdin.ts
@@ -29,7 +29,7 @@ const {
 export const unwrapValidationErrorResponse = (
   response: ValidationErrorResponse
 ): Error => {
-  return response.errors[0].error.errors[0];
+  return response?.errors[0]?.error?.errors[0];
 };
 
 export const isCommonErrorResponse = (


### PR DESCRIPTION
Logs a more useful error message in case the user runs `yarn crowdin:download` without uploading the branch to Crowdin first.