### PR TITLE
Preserve translations when source string is updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "name": "@mollie/crowdin-cli",
   "author": {

--- a/src/lib/crowdin.ts
+++ b/src/lib/crowdin.ts
@@ -110,6 +110,7 @@ export const updateOrRestoreFile = async (
 
   return sourceFilesApi.updateOrRestoreFile(CROWDIN_PROJECT_ID, fileId, {
     storageId: storage.data.id,
+    updateOption: SourceFilesModel.UpdateOption.KEEP_TRANSLATIONS,
   });
 };
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,8 +8,10 @@ import download from "../src/download";
 import upload from "../src/upload";
 import deleteBranch from "../src/delete-branch";
 
-jest.mock("@crowdin/crowdin-api-client", () =>
-  jest.fn().mockReturnValue({
+jest.mock("@crowdin/crowdin-api-client", () => ({
+  __esModule: true,
+  ...jest.requireActual<any>("@crowdin/crowdin-api-client"),
+  default: jest.fn().mockReturnValue({
     uploadStorageApi: {
       addStorage: jest.fn().mockResolvedValue({
         data: { id: 324234 },
@@ -37,12 +39,13 @@ jest.mock("@crowdin/crowdin-api-client", () =>
         data: { id: 234234 },
       }),
     },
-  })
-);
+  }),
+}));
 
 jest.mock(
   "axios",
   jest.fn().mockReturnValue({
+    ...jest.requireActual("axios"),
     get: jest.fn().mockResolvedValue({
       statusText: "OK",
       data: {


### PR DESCRIPTION
According to [Crowdin's API Reference](https://developer.crowdin.com/api/v2/#operation/api.projects.files.put), when we call `updateOrRestoreFile()` the default `updateOption` is `clear_translations_and_approvals`.
So whenever we update a source string in the code and run `mollie-crowdin upload ...` it will remove all the translations for that string (since the source string _could_ have a different meaning now).

This causes a few inconveniences, like when we have to fix a typo in the source string, because then we need to input all the translations again. If we don't, the next time we run `mollie-crowdin download` all the translations will be reverted to the same value as the source string (e.g. if our source string is in english and you change it, then all translations for that string will be lost and the languages will use the english text instead).

To avoid this, I propose to change the `updateOption` to `keep_translations`, so we don't loose the translations anymore when the source string is changed. This option will still remove the validation/proofread check, as an indication to translators that they should review that translation again (just in case). If we want to keep the validation check then we can send `updateOption` as `keep_translations_and_approvals`.