### PR TITLE
Add transient dependencies & pin crowdin/crowdin-api-client package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,10 @@
     "tsc:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@crowdin/crowdin-api-client": "^1.10.3",
+    "@crowdin/crowdin-api-client": "1.15.2",
     "@formatjs/cli": "^3.0.5",
+    "axios": "^0.21.3",
+    "chalk": "^4.0.0",
     "commander": "^7.0.0",
     "dotenv": "^8.2.0",
     "mkdirp": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,12 +853,12 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@crowdin/crowdin-api-client@^1.10.3":
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/@crowdin/crowdin-api-client/-/crowdin-api-client-1.10.3.tgz#9be5ca4a98d507966442f41b6772d1b11c7cbed1"
-  integrity sha512-2udOZr879tDAuoJnx77OI8TCdaap4zxzcXmr0qRvxMSgOcGLUsmzGD8+OJRIqUnBJipeRPVPkSfZFDLl1NBOAg==
+"@crowdin/crowdin-api-client@1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@crowdin/crowdin-api-client/-/crowdin-api-client-1.15.2.tgz#3d1fd443d178973e0c69d1a28d199a4db708ee3a"
+  integrity sha512-kJnmsrGdZRn8j3+fxZnU15Te2C8n40rYdbGIehAgwiclWllEASCPikMXdO3chOjeDCpy01+jx1Z9gfCJSe7y1w==
   dependencies:
-    axios "^0.21.1"
+    axios "0.21.3"
 
 "@formatjs/cli@^3.0.5":
   version "3.0.5"
@@ -1709,7 +1709,14 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
 
-axios@^0.21.1:
+axios@0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.3.tgz#f85d9b747f9b66d59ca463605cedf1844872b82e"
+  integrity sha512-JtoZ3Ndke/+Iwt5n+BgSli/3idTvpt5OjKyoCmz4LX5+lPiY5l7C1colYezhlxThjNa/NhngCUWZSZFypIFuaA==
+  dependencies:
+    follow-redirects "^1.14.0"
+
+axios@^0.21.3:
   version "0.21.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
@@ -2146,7 +2153,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.1, colorette@^1.2.2:
+colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
@@ -3064,9 +3071,9 @@ flatted@^2.0.0:
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
 follow-redirects@^1.14.0:
-  version "1.14.8"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
-  integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Some transient dependencies weren't defined, causing problems with newer/stricter package managers. The crowdin/crowdin-api-client package has introduced a plethora of breaking changes without respecting semver, so I'm pinning the package to the latest version not causing problems.